### PR TITLE
Remove extra spaces in the imprint link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="my-footer z-depth-2">
     <p>
-        <a class="waves-effect waves-teal btn-flat my-imprint-link" href="{{ " /imprint.html " | prepend: site.baseurl }}">{{ site.imprint_btn }}</a>        {% if site.email %}<a href="mailto:{{ site.email }}" class="waves-effect waves-teal btn-flat my-mail-link"><i class="fa fa-envelope-o"></i></a>{%
+        <a class="waves-effect waves-teal btn-flat my-imprint-link" href="{{ "/imprint.html" | prepend: site.baseurl }}">{{ site.imprint_btn }}</a>        {% if site.email %}<a href="mailto:{{ site.email }}" class="waves-effect waves-teal btn-flat my-mail-link"><i class="fa fa-envelope-o"></i></a>{%
         endif %} {% if site.github_username %}
         <a href="https://github.com/{{ site.github_username }}" class="waves-effect waves-teal btn-flat my-github-link"><i class="fa fa-github"></i></a>{% endif %} {% if site.twitter_username %}<a href="https://twitter.com/{{ site.twitter_username }}"
             class="waves-effect waves-teal btn-flat my-twitter-link"><i class="fa fa-twitter"></i></a>{% endif %}


### PR DESCRIPTION
Hi @lukas-h, I'm really enjoying your theme and I wanted to help contribute a minor improvement. 

When the config file lists anything other that an empty string (`""`) for the `baseurl` the imprint link will be rendered with a space causing a 404 error.

For example, when setting up my site as 

```yml
baseurl: "/blog/"
```
the link takes me to `http://127.0.0.1:4000/blog%20/imprint.html`

Removing those spaces fixes that. 

Thanks for the cool theme!